### PR TITLE
fix: edit footer to be fixed on bottom on larger screen sizes

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -8,11 +8,10 @@
 body{
     font-family: Lato, sans-serif;
     font-weight: 400;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
-
-main > .container {
-    padding: 60px 15px 0;
-  }
 
 /* Header Styling */
 
@@ -128,6 +127,11 @@ footer {
     flex-wrap: wrap;
     padding: 0.5rem 1rem;
 }*/
+
+.body-container {
+  flex-grow: 1;
+  padding-top: 20px;
+}
 
 /* Sign Up form */
 


### PR DESCRIPTION
Footer was not staying on the bottom on larger screens:

- body: changed display to flex, flex-direction to column and add min-height 100vh.
- body-container: add flex grow of 1 and a padding top of 20px so the content is not so close to the navbar

![Screenshot 2023-03-19 at 10 35 07](https://user-images.githubusercontent.com/15631445/226170088-c33b42d1-48d2-4999-bdae-b42d8d6c122a.JPG)


![Screenshot 2023-03-19 at 10 32 10](https://user-images.githubusercontent.com/15631445/226169919-39e98d1a-9506-4d95-8732-2d95e24f4500.JPG)
